### PR TITLE
Added Json Property for ValueListApiModel Items

### DIFF
--- a/WebService.Test/Controllers/KeyValueControllerTest.cs
+++ b/WebService.Test/Controllers/KeyValueControllerTest.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.IoTSolutions.StorageAdapter.WebService.v1.Controllers;
 using Microsoft.Azure.IoTSolutions.StorageAdapter.WebService.v1.Exceptions;
 using Microsoft.Azure.IoTSolutions.StorageAdapter.WebService.Wrappers;
 using Moq;
+using Newtonsoft.Json.Linq;
 using WebService.Test.helpers;
 using Xunit;
 
@@ -113,6 +114,9 @@ namespace WebService.Test.Controllers
                 .ReturnsAsync(models);
 
             var result = await controller.Get(collectionId);
+
+            var jsonResponse = JObject.FromObject(result);
+            Assert.True(jsonResponse.TryGetValue("Items", out JToken value));
 
             Assert.Equal(result.Items.Count(), models.Length);
             foreach (var item in result.Items)

--- a/WebService/v1/Models/ValueListApiModel.cs
+++ b/WebService/v1/Models/ValueListApiModel.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.IoTSolutions.StorageAdapter.WebService.v1.Models
 {
     public class ValueListApiModel
     {
+        [JsonProperty("Items")]
         public readonly IEnumerable<ValueApiModel> Items;
 
         [JsonProperty("$metadata")]


### PR DESCRIPTION
# Change type <!-- [x] in all the boxes that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**
- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

# Description and Motivation <!-- Information and Context so others can review your pull request -->
The java service returns a capital "Items" in the json response, whereas the dotnet service didn't include a Json Property tag for the ValueListApiModel, returning a lowercase "items" in the response. 

This change includes a Json Property tag for format consistency and an addition to the webservice test to check for the string "Items"