### PR TITLE
Use env vars in launchSettings.json

### DIFF
--- a/WebService/Properties/launchSettings.json
+++ b/WebService/Properties/launchSettings.json
@@ -13,7 +13,7 @@
             "launchBrowser": true,
             "launchUrl": "http://localhost:9022/v1/status",
             "environmentVariables": {
-                "PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING": "..."
+                "PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING": "$(PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING)"
             }
         },
         "WebService": {
@@ -21,7 +21,7 @@
             "launchBrowser": true,
             "launchUrl": "http://localhost:9022/v1/status",
             "environmentVariables": {
-                "PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING": "..."
+                "PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING": "$(PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING)"
             },
             "applicationUrl": "http://localhost:9022/v1/status"
         }


### PR DESCRIPTION
# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

# Description and Motivation <!-- Information and Context so others can review your pull request -->

Editing launchSettings.json to reference actual environment variables.  This will make the solution debuggable from Visual Studio without needing to edit the launchSettings.json file. This should reduce the risk of checking in launchSettings.json with real connection strings (and secrets) in it. 
