### PR TITLE
Docker container excessively privileged running root user (#114)

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -4,7 +4,14 @@ MAINTAINER Devis Lucato (https://github.com/dluc)
 
 LABEL Tags="Azure,IoT,Solutions,IoT Hub,Storage,.NET"
 
+ARG user=pcsuser
+
+RUN useradd -m -s /bin/bash -U $user
+
 ENTRYPOINT ["/bin/bash", "/app/run.sh"]
 
 COPY . /app/
+RUN chown -R $user.$user /app
 WORKDIR /app
+
+USER $user


### PR DESCRIPTION
* Add default non-root user 'pcsuser'
* Run service as 'pcsuser'

PBI[2211778]

# Change type <!-- [x] in all the boxes that apply -->

- [] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

# Description and Motivation <!-- Information and Context so others can review your pull request -->

Without explicitly defining a running user in a Dockerfile definition, the root user is utilized by default.
Each respective Dockerfile should explicitly define a user and mandate that user to be the service runner via the USER instruction. Further, the service user should also have a defined GROUP. Without one, the primary group for the user will fall back to the root group.
