### PR TITLE
Before build, detect whether secrets are available

### DIFF
--- a/scripts/env-vars-check
+++ b/scripts/env-vars-check
@@ -3,13 +3,20 @@
 # Note: Windows Bash doesn't support shebang extra params
 set -e
 
-# Do not run during Travis CI builds, to avoid failures in case of third party PRs
-if [[ "$TRAVIS_SECURE_ENV_VARS" == "false" ]]; then
-    echo "Info: skipping env vars check during Travis CI build"
-    exit 0
-fi
 
-if [[ -z "$PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING" ]]; then
+# Before checking all the env vars, detect whether secrets, usually encrypted, are available or not.
+# Secrets are not available when building a pull request, so the script will not check for those.
+detect_secrets() {
+    SECRETS_AVAILABLE="true"
+    if [[ "$TRAVIS_PULL_REQUEST" != "" && "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+        SECRETS_AVAILABLE="false"
+        echo "Warning: secrets and encrypted variables are not available when testing pull requests."
+    fi
+}
+
+detect_secrets
+
+if [[ -z "$PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING" && "$SECRETS_AVAILABLE" = "true" ]]; then
     echo "Error: the PCS_STORAGEADAPTER_DOCUMENTDB_CONNSTRING environment variable is not defined."
     exit -1
 fi


### PR DESCRIPTION
Before checking all the env vars, detect whether secrets, usually encrypted, are available or not. Secrets are not available when building a pull request, so the script will not check for those.

# Description and Motivation <!-- Info & Context so we can review your pull request -->

Before checking all the env vars, detect whether secrets, usually encrypted, are available or not. Secrets are not available when building a pull request, so the script will not check for those.

This change allows the build to run for pull requests, e.g. unit tests can be executed. 
Functional tests requiring secrets won't work.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly