### PR TITLE
Support exceptions without stack trace

### DIFF
--- a/WebService.Test/WebService.Test.csproj
+++ b/WebService.Test/WebService.Test.csproj
@@ -8,7 +8,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/WebService.Test/v1/Controllers/ValuesControllerTest.cs
+++ b/WebService.Test/v1/Controllers/ValuesControllerTest.cs
@@ -15,16 +15,16 @@ using Newtonsoft.Json.Linq;
 using WebService.Test.helpers;
 using Xunit;
 
-namespace WebService.Test.Controllers
+namespace WebService.Test.v1.Controllers
 {
-    public class KeyValueControllerTest
+    public class ValuesControllerTest
     {
         private readonly Mock<IKeyValueContainer> mockContainer;
         private readonly Mock<IKeyGenerator> mockGenerator;
         private readonly ValuesController controller;
         private readonly Random rand = new Random();
 
-        public KeyValueControllerTest()
+        public ValuesControllerTest()
         {
             this.mockContainer = new Mock<IKeyValueContainer>();
             this.mockGenerator = new Mock<IKeyGenerator>();
@@ -128,6 +128,7 @@ namespace WebService.Test.Controllers
                 Assert.Equal(item.Metadata["$modified"], model.Timestamp.ToString(CultureInfo.InvariantCulture));
                 Assert.Equal(item.Metadata["$uri"], $"/v1/collections/{collectionId}/values/{model.Key}");
             }
+
             Assert.Equal(result.Metadata["$type"], "ValueList;1");
             Assert.Equal(result.Metadata["$uri"], $"/v1/collections/{collectionId}/values");
 

--- a/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
+++ b/WebService.Test/v1/Filters/ExceptionsFilterAttributeTest.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Azure.IoTSolutions.StorageAdapter.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.StorageAdapter.WebService.v1.Filters;
+using Moq;
+using WebService.Test.helpers;
+using Xunit;
+
+namespace WebService.Test.v1.Filters
+{
+    public class ExceptionsFilterAttributeTest
+    {
+        private readonly ExceptionsFilterAttribute target;
+        private readonly Mock<ILogger> logger;
+
+        public ExceptionsFilterAttributeTest()
+        {
+            this.logger = new Mock<ILogger>();
+            this.target = new ExceptionsFilterAttribute(this.logger.Object);
+        }
+
+        /// <summary>
+        /// When handling unknown/unexpected exceptions, the stack trace could be null,
+        /// the filter must support this scenario.
+        /// </summary>
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void Doesnt_Fail_When_StackTraces_AreNull()
+        {
+            // Arrange
+            var internalException = new Mock<Exception>();
+            var exception = new Exception("", internalException.Object);
+            internalException.SetupGet(x => x.StackTrace).Returns((string) null);
+
+            var context = new ExceptionContext(
+                new ActionContext(
+                    new DefaultHttpContext(),
+                    new RouteData(),
+                    new ActionDescriptor(),
+                    new ModelStateDictionary()),
+                new List<IFilterMetadata>()) { Exception = exception };
+
+            // Act
+            this.target.OnException(context);
+
+            // Assert
+            var result = (ObjectResult) context.Result;
+            Assert.Equal((int) HttpStatusCode.InternalServerError, result.StatusCode.Value);
+
+            var content = (Dictionary<string, object>) result.Value;
+            Assert.True(content.ContainsKey("StackTrace"));
+            Assert.True(content.ContainsKey("InnerExceptionStackTrace"));
+            Assert.Null(content["StackTrace"]);
+            Assert.Null(content["InnerExceptionStackTrace"]);
+        }
+    }
+}

--- a/WebService/v1/Filters/ExceptionsFilterAttribute.cs
+++ b/WebService/v1/Filters/ExceptionsFilterAttribute.cs
@@ -94,14 +94,14 @@ namespace Microsoft.Azure.IoTSolutions.StorageAdapter.WebService.v1.Filters
 
             if (stackTrace)
             {
-                error["StackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                error["StackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
 
                 if (e.InnerException != null)
                 {
                     e = e.InnerException;
                     error["InnerExceptionMessage"] = e.Message;
                     error["InnerExceptionType"] = e.GetType().FullName;
-                    error["InnerExceptionStackTrace"] = e.StackTrace.Split(new[] { "\n" }, StringSplitOptions.None);
+                    error["InnerExceptionStackTrace"] = e.StackTrace?.Split(new[] { "\n" }, StringSplitOptions.None);
                 }
             }
 


### PR DESCRIPTION
# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

# Description and Motivation <!-- Information and Context so others can review your pull request -->

When handling some unknown/unexpected exceptions, the web service fails with NullRefException, without providing information about the actual problem. This is happening whenever the exception or the inner exception don't have a stack trace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/pcs-storage-adapter-dotnet/57)
<!-- Reviewable:end -->
